### PR TITLE
Update documentation for flow: flow-donation-account-key

### DIFF
--- a/flows-accounts/account-platform-key-flow.md
+++ b/flows-accounts/account-platform-key-flow.md
@@ -80,6 +80,8 @@ The `GeneralPlatformKey` formula concatenates:
 * Colon separator (`:`)
 * External platform key
 
+The formula expression uses `{!current}` references for proper string concatenation: `{!Platform}{!current}amp;{!current}quot;:{!current}quot;{!current}amp;{!Key}`
+
 This standardised format ensures consistent key generation across all donation platforms integrated with MoveData.
 
 ## Error Handling


### PR DESCRIPTION
Reviewed both Lightning flows for changes. The MoveData_Donation_Account_Duplicate.flow-meta.xml file showed no functional changes (only location coordinates which are not considered changes per requirements). However, the MoveData_Donation_Account_Key.flow-meta.xml file shows a change in the GeneralPlatformKey formula expression where '{!previous}' references were changed to '{!current}'. Updated the documentation to reflect this formula change.