### PR TITLE
Update documentation for flow: flow-donation-account-key

### DIFF
--- a/flows-accounts/account-platform-key-flow.md
+++ b/flows-accounts/account-platform-key-flow.md
@@ -10,7 +10,7 @@ This flow is self-documenting and should be viewed within Salesforce (Setup -> P
 **Label:** \[MoveData] General: Account - Platform Key\
 **Type:** Auto-Launched Flow Template\
 **API Version:** 49.0\
-**Status:** Active
+**Status:** Draft
 
 This utility flow generates standardised platform keys for account records by combining platform identifiers and keys into a consistent format for tracking and integration purposes. These platform keys are essential for matching existing records during donation processing across multiple fundraising platforms.
 


### PR DESCRIPTION
Reviewed both Lightning flows and identified one change: In MoveData_Donation_Account_Key.flow-meta.xml, the status changed from 'Active' to 'Draft' and the GeneralPlatformKey formula was updated to use '{!current}' instead of '{!previous}' references. Updated the Status field in the Account Platform Key Flow documentation accordingly.